### PR TITLE
добавил db_table для JobCategory и JobResponse

### DIFF
--- a/backend/orders/models.py
+++ b/backend/orders/models.py
@@ -106,6 +106,7 @@ class JobCategory(models.Model):
     )
 
     class Meta:
+        db_table = 'orders_jobcategory'
         ordering = ('id',)
         verbose_name = 'Специализация'
         verbose_name_plural = 'Специализации'
@@ -255,6 +256,7 @@ class JobResponse(models.Model):
                                    related_name='responses')
 
     class Meta:
+        db_table = 'orders_jobresponse'
         unique_together = ('freelancer', 'job')
         verbose_name = 'Отклик'
         verbose_name_plural = 'Отклики'


### PR DESCRIPTION
Возникала ошибка в БД:
`err: Traceback (most recent call last):
err:   File "/usr/local/lib/python3.10/site-packages/django/***/backends/utils.py", line 89, in _execute
err:     return self.cursor.execute(sql, params)
err: psycopg2.errors.UndefinedTable: relation "orders_jobcategory" does not exist`

При просмотре выяснил, что Postgres для моей модели JobCategory почему-то создавал таблицу `orders_category` вместо `orders_jobcategory` (хотя в sqlite такого не происходит), аналогично JobResponse. Добавил в class Meta: моделей опцию `db_name`